### PR TITLE
Fixed '.*' version recognition

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -149,6 +149,7 @@ class TestVersionSpec(unittest.TestCase):
             ('1.7', False),   ('1.5*', False),    ('>=1.5', True),
             ('!=1.5', True),  ('!=1.7.1', False), ('==1.7.1', True),
             ('==1.7', False), ('==1.7.2', False), ('==1.7.1.0', True),
+            ('1.7.1.*', True), ('1.7.*', True), ('1.7.10', False),
             ]:
             m = VersionSpec(vspec)
             self.assertEqual(m.match('1.7.1'), res)


### PR DESCRIPTION
When using something like

```yaml
    run:    
        - vc 14.*
```

in the ``meta.yaml`` (as it is done in the numpy recipe for Windows), one would expect, that is matches `'14.0'` as well as `'14'`.

With the current `version.py` of libconda, however, the `'14.*'` is converted in a regex like `r'(14\..*)$'` which only matches `'14.0'` and not `'14'`. This results in the fact that the [constructor](https://github.com/conda/constructor) package with a `construct.yaml` like

```yaml
name: numpy-conda
version: 0.01
channels:
    - http://repo.continuum.io/pkgs/main
specs:
    - numpy
```

fails on Windows with

```
Error:  Dependencies missing in current win-64 channels:
  - numpy -> python >=3.5,<3.6.0a0 -> vc 14.*
  - numpy -> vc 14.*
  - numpy -> python >=2.7,<2.8.0a0 -> vc 9.*
  - numpy -> vc 9.*
  - numpy -> python >=3.6,<3.7.0a0 -> vc 14.*
  - python -> vc 9.*
  - python -> vc 14.*
```

because it cannot find a package matching `'vc 14.*'` (although there is a package named `'vc 14'`).

This PR fixes this issue. Instead of
```python
rx = rx.replace('.', r'\.')
```
we use a regex
```python
rx = re.sub(r'\.(?!\*)', r'\.', rx)
```
to replace `'.'` only if it is not followed by a `'*'` (i.e. we do not replace `'.*'`).

Similarly, instead of
```python
rx = rx.replace('*', r'.*')
```
we use
```python
rx = re.sub(r'(?<!\.)\*')`, r'.*', rx)
```
to replace the `'*'` only if it is not preceded by a `'.'`.

`'.*'` is then treated separately with
```python
rx = rx.replace('.*', r'(:?\..*|$)')
```

The pattern we use here, `r'(:?\..*|$)'`, only matches if we have a `'.'` followed by something else, or the end of the version string.

Hence, the resulting pattern (`rx`) of '14.*' then becomes `r'(14(:?\\..*|$))$'`, which matches `'14'`, `'14.x'`, but not `'140'` or `'140.x'`.
